### PR TITLE
Add logistics v2 schemas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 # Caches
 **/__pycache__
 .mypy_cache
+.pytest_cache
 dist/
+
+.env*

--- a/cofactr/graph.py
+++ b/cofactr/graph.py
@@ -4,7 +4,6 @@
 import dataclasses
 import json
 from typing import Any, Dict, List, Literal, Optional
-from h11 import Response
 
 # 3rd Party Modules
 import httpx
@@ -86,7 +85,7 @@ def get_orgs(
     limit,
     schema,
     timeout,
-) -> Response:
+) -> httpx.Response:
     """Get orgs."""
 
     res = httpx.get(

--- a/cofactr/schema/__init__.py
+++ b/cofactr/schema/__init__.py
@@ -94,5 +94,5 @@ schema_to_supplier: Dict[SupplierSchemaName, Callable] = {
     SupplierSchemaName.INTERNAL: identity,
     SupplierSchemaName.FLAGSHIP: FlagshipSeller,
     SupplierSchemaName.LOGISTICS: FlagshipSeller,
-    OrgSchemaName.LOGISTICS_V2: LogisticsV2Seller,
+    SupplierSchemaName.LOGISTICS_V2: LogisticsV2Seller,
 }

--- a/cofactr/schema/__init__.py
+++ b/cofactr/schema/__init__.py
@@ -12,6 +12,8 @@ from cofactr.schema.flagship_v2.part import Part as FlagshipV2Part
 from cofactr.schema.flagship_v3.part import Part as FlagshipV3Part
 from cofactr.schema.logistics.part import Part as LogisticsPart
 from cofactr.schema.logistics_v2.part import Part as LogisticsV2Part
+from cofactr.schema.logistics_v2.offer import Offer as LogisticsV2Offer
+from cofactr.schema.logistics_v2.seller import Seller as LogisticsV2Seller
 from cofactr.schema.logistics_v3.part import Part as LogisticsV3Part
 from cofactr.schema.logistics_v4.part import Part as LogisticsV4Part
 from cofactr.schema.flagship.seller import Seller as FlagshipSeller
@@ -51,12 +53,14 @@ class OfferSchemaName(str, Enum):
     INTERNAL = "internal"
     FLAGSHIP = "flagship"
     LOGISTICS = "logistics"
+    LOGISTICS_V2 = "logistics-v2"
 
 
 schema_to_offer: Dict[OfferSchemaName, Callable] = {
     OfferSchemaName.INTERNAL: identity,
     OfferSchemaName.FLAGSHIP: FlagshipOffer,
     OfferSchemaName.LOGISTICS: LogisticsOffer,
+    OfferSchemaName.LOGISTICS_V2: LogisticsV2Offer,
 }
 
 
@@ -66,12 +70,14 @@ class OrgSchemaName(str, Enum):
     INTERNAL = "internal"
     FLAGSHIP = "flagship"
     LOGISTICS = "logistics"
+    LOGISTICS_V2 = "logistics-v2"
 
 
 schema_to_org: Dict[OrgSchemaName, Callable] = {
     OrgSchemaName.INTERNAL: identity,
     OrgSchemaName.FLAGSHIP: FlagshipSeller,
     OrgSchemaName.LOGISTICS: FlagshipSeller,
+    OrgSchemaName.LOGISTICS_V2: LogisticsV2Seller,
 }
 
 
@@ -81,10 +87,12 @@ class SupplierSchemaName(str, Enum):
     INTERNAL = "internal"
     FLAGSHIP = "flagship"
     LOGISTICS = "logistics"
+    LOGISTICS_V2 = "logistics-v2"
 
 
 schema_to_supplier: Dict[SupplierSchemaName, Callable] = {
     SupplierSchemaName.INTERNAL: identity,
     SupplierSchemaName.FLAGSHIP: FlagshipSeller,
     SupplierSchemaName.LOGISTICS: FlagshipSeller,
+    OrgSchemaName.LOGISTICS_V2: LogisticsV2Seller,
 }

--- a/cofactr/schema/logistics_v2/offer.py
+++ b/cofactr/schema/logistics_v2/offer.py
@@ -1,0 +1,51 @@
+"""Part offer class."""
+# Standard Modules
+from dataclasses import dataclass
+from typing import List, Literal, Optional
+
+# Local Modules
+from cofactr.kb.entity.types import PricePoint
+from cofactr.schema.logistics_v2.seller import Seller
+
+
+@dataclass
+class Offer:  # pylint: disable=too-many-instance-attributes
+    """Part offer."""
+
+    part: str  # Cofactr part ID.
+    seller: Seller
+    is_authorized: bool  # defaults to False.
+    status: Optional[Literal["buyable", "quotable", "maybe"]]
+    shipping_lead: Optional[int]
+    # Country code for the current location of this part, defaults to
+    # that of the distributor.
+    ships_from_country: Optional[str]
+    # Stock Keeping Unit used internally by distributor.
+    sku: Optional[str]
+    # Number of units available to be shipped (aka Stock, Quantity).
+    inventory_level: Optional[int]
+    # Packaging of parts (eg Tape, Reel).
+    packaging: Optional[str]
+    # Minimum Order Quantity: smallest number of parts that can be
+    # purchased.
+    moq: Optional[int]
+    prices: Optional[List[PricePoint]]
+    # The last time data was fetched from external sources.
+    updated_at: str
+    # Number of days to acquire parts from factory.
+    factory_lead_days: Optional[int]
+    # Number of parts on order from factory.
+    on_order_quantity: Optional[int]
+    # Order multiple for factory orders.
+    factory_pack_quantity: Optional[int]
+    # Number of items which must be ordered together.
+    order_multiple: Optional[int]
+    # The quantity of parts as packaged by the seller.
+    multipack_quantity: Optional[int]
+    # Did a currency conversion happen?
+    is_foreign: bool
+
+    def __post_init__(self):
+        """Convert types."""
+
+        self.seller = Seller(**self.seller)  # pylint: disable=not-a-mapping

--- a/cofactr/schema/logistics_v2/seller.py
+++ b/cofactr/schema/logistics_v2/seller.py
@@ -1,0 +1,24 @@
+"""Part seller class."""
+# Standard Modules
+from dataclasses import dataclass
+from typing import Dict, List, Literal, Optional
+
+
+@dataclass
+class Seller:  # pylint: disable=too-many-instance-attributes
+    """Part seller."""
+
+    id: str
+    label: str
+    aliases: List[str]
+    authenticity_score: Optional[int]
+    availability_score: Optional[int]
+    additional_markup: Optional[float]
+    additional_fee: Optional[float]
+    certifications: List[str]
+    #  A separate flag that's independent from accuracy.
+    is_buyable: bool
+    lead: Optional[int]
+    free_ship: Dict[Literal["threshold", "shipping_lead"], Optional[int]]
+    shipping_options: List[Dict[Literal["price", "shipping_lead"], int]]
+    rfq_email: Optional[str]

--- a/poetry.lock
+++ b/poetry.lock
@@ -266,8 +266,8 @@ optional = false
 python-versions = ">=3.6"
 
 [package.extras]
-dev = ["pre-commit", "tox"]
-testing = ["pytest", "pytest-benchmark"]
+testing = ["pytest-benchmark", "pytest"]
+dev = ["tox", "pre-commit"]
 
 [[package]]
 name = "py"
@@ -330,6 +330,17 @@ tomli = ">=1.0.0"
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
 
 [[package]]
+name = "python-dotenv"
+version = "0.21.0"
+description = "Read key-value pairs from a .env file and set them as environment variables"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+cli = ["click (>=5.0)"]
+
+[[package]]
 name = "rfc3986"
 version = "1.5.0"
 description = "Validating URI References per RFC 3986"
@@ -386,7 +397,7 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.10"
-content-hash = "d1dd38612562137d3801a4b8409ed81c34db1146e113f9e5a935fd36f083b35e"
+content-hash = "2b342093f25106586819d2c6c2814d970907e63c4d8603ab3c28140d60f77d43"
 
 [metadata.files]
 anyio = []
@@ -413,80 +424,13 @@ pathspec = []
 platformdirs = []
 pluggy = []
 py = []
-pylint = [
-    {file = "pylint-2.13.8-py3-none-any.whl", hash = "sha256:f87e863a0b08f64b5230e7e779bcb75276346995737b2c0dc2793070487b1ff6"},
-    {file = "pylint-2.13.8.tar.gz", hash = "sha256:ced8968c3b699df0615e2a709554dec3ddac2f5cd06efadb69554a69eeca364a"},
-]
+pylint = []
 pyparsing = []
 pytest = []
+python-dotenv = []
 rfc3986 = []
 sniffio = []
 tomli = []
 types-urllib3 = []
 typing-extensions = []
-wrapt = [
-    {file = "wrapt-1.14.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:1b376b3f4896e7930f1f772ac4b064ac12598d1c38d04907e696cc4d794b43d3"},
-    {file = "wrapt-1.14.1-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:903500616422a40a98a5a3c4ff4ed9d0066f3b4c951fa286018ecdf0750194ef"},
-    {file = "wrapt-1.14.1-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:5a9a0d155deafd9448baff28c08e150d9b24ff010e899311ddd63c45c2445e28"},
-    {file = "wrapt-1.14.1-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:ddaea91abf8b0d13443f6dac52e89051a5063c7d014710dcb4d4abb2ff811a59"},
-    {file = "wrapt-1.14.1-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:36f582d0c6bc99d5f39cd3ac2a9062e57f3cf606ade29a0a0d6b323462f4dd87"},
-    {file = "wrapt-1.14.1-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:7ef58fb89674095bfc57c4069e95d7a31cfdc0939e2a579882ac7d55aadfd2a1"},
-    {file = "wrapt-1.14.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:e2f83e18fe2f4c9e7db597e988f72712c0c3676d337d8b101f6758107c42425b"},
-    {file = "wrapt-1.14.1-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:ee2b1b1769f6707a8a445162ea16dddf74285c3964f605877a20e38545c3c462"},
-    {file = "wrapt-1.14.1-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:833b58d5d0b7e5b9832869f039203389ac7cbf01765639c7309fd50ef619e0b1"},
-    {file = "wrapt-1.14.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:80bb5c256f1415f747011dc3604b59bc1f91c6e7150bd7db03b19170ee06b320"},
-    {file = "wrapt-1.14.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:07f7a7d0f388028b2df1d916e94bbb40624c59b48ecc6cbc232546706fac74c2"},
-    {file = "wrapt-1.14.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:02b41b633c6261feff8ddd8d11c711df6842aba629fdd3da10249a53211a72c4"},
-    {file = "wrapt-1.14.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2fe803deacd09a233e4762a1adcea5db5d31e6be577a43352936179d14d90069"},
-    {file = "wrapt-1.14.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:257fd78c513e0fb5cdbe058c27a0624c9884e735bbd131935fd49e9fe719d310"},
-    {file = "wrapt-1.14.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:4fcc4649dc762cddacd193e6b55bc02edca674067f5f98166d7713b193932b7f"},
-    {file = "wrapt-1.14.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:11871514607b15cfeb87c547a49bca19fde402f32e2b1c24a632506c0a756656"},
-    {file = "wrapt-1.14.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:8ad85f7f4e20964db4daadcab70b47ab05c7c1cf2a7c1e51087bfaa83831854c"},
-    {file = "wrapt-1.14.1-cp310-cp310-win32.whl", hash = "sha256:a9a52172be0b5aae932bef82a79ec0a0ce87288c7d132946d645eba03f0ad8a8"},
-    {file = "wrapt-1.14.1-cp310-cp310-win_amd64.whl", hash = "sha256:6d323e1554b3d22cfc03cd3243b5bb815a51f5249fdcbb86fda4bf62bab9e164"},
-    {file = "wrapt-1.14.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:43ca3bbbe97af00f49efb06e352eae40434ca9d915906f77def219b88e85d907"},
-    {file = "wrapt-1.14.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:6b1a564e6cb69922c7fe3a678b9f9a3c54e72b469875aa8018f18b4d1dd1adf3"},
-    {file = "wrapt-1.14.1-cp35-cp35m-manylinux2010_i686.whl", hash = "sha256:00b6d4ea20a906c0ca56d84f93065b398ab74b927a7a3dbd470f6fc503f95dc3"},
-    {file = "wrapt-1.14.1-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:a85d2b46be66a71bedde836d9e41859879cc54a2a04fad1191eb50c2066f6e9d"},
-    {file = "wrapt-1.14.1-cp35-cp35m-win32.whl", hash = "sha256:dbcda74c67263139358f4d188ae5faae95c30929281bc6866d00573783c422b7"},
-    {file = "wrapt-1.14.1-cp35-cp35m-win_amd64.whl", hash = "sha256:b21bb4c09ffabfa0e85e3a6b623e19b80e7acd709b9f91452b8297ace2a8ab00"},
-    {file = "wrapt-1.14.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:9e0fd32e0148dd5dea6af5fee42beb949098564cc23211a88d799e434255a1f4"},
-    {file = "wrapt-1.14.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9736af4641846491aedb3c3f56b9bc5568d92b0692303b5a305301a95dfd38b1"},
-    {file = "wrapt-1.14.1-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5b02d65b9ccf0ef6c34cba6cf5bf2aab1bb2f49c6090bafeecc9cd81ad4ea1c1"},
-    {file = "wrapt-1.14.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:21ac0156c4b089b330b7666db40feee30a5d52634cc4560e1905d6529a3897ff"},
-    {file = "wrapt-1.14.1-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:9f3e6f9e05148ff90002b884fbc2a86bd303ae847e472f44ecc06c2cd2fcdb2d"},
-    {file = "wrapt-1.14.1-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:6e743de5e9c3d1b7185870f480587b75b1cb604832e380d64f9504a0535912d1"},
-    {file = "wrapt-1.14.1-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:d79d7d5dc8a32b7093e81e97dad755127ff77bcc899e845f41bf71747af0c569"},
-    {file = "wrapt-1.14.1-cp36-cp36m-win32.whl", hash = "sha256:81b19725065dcb43df02b37e03278c011a09e49757287dca60c5aecdd5a0b8ed"},
-    {file = "wrapt-1.14.1-cp36-cp36m-win_amd64.whl", hash = "sha256:b014c23646a467558be7da3d6b9fa409b2c567d2110599b7cf9a0c5992b3b471"},
-    {file = "wrapt-1.14.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:88bd7b6bd70a5b6803c1abf6bca012f7ed963e58c68d76ee20b9d751c74a3248"},
-    {file = "wrapt-1.14.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b5901a312f4d14c59918c221323068fad0540e34324925c8475263841dbdfe68"},
-    {file = "wrapt-1.14.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d77c85fedff92cf788face9bfa3ebaa364448ebb1d765302e9af11bf449ca36d"},
-    {file = "wrapt-1.14.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8d649d616e5c6a678b26d15ece345354f7c2286acd6db868e65fcc5ff7c24a77"},
-    {file = "wrapt-1.14.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:7d2872609603cb35ca513d7404a94d6d608fc13211563571117046c9d2bcc3d7"},
-    {file = "wrapt-1.14.1-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:ee6acae74a2b91865910eef5e7de37dc6895ad96fa23603d1d27ea69df545015"},
-    {file = "wrapt-1.14.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:2b39d38039a1fdad98c87279b48bc5dce2c0ca0d73483b12cb72aa9609278e8a"},
-    {file = "wrapt-1.14.1-cp37-cp37m-win32.whl", hash = "sha256:60db23fa423575eeb65ea430cee741acb7c26a1365d103f7b0f6ec412b893853"},
-    {file = "wrapt-1.14.1-cp37-cp37m-win_amd64.whl", hash = "sha256:709fe01086a55cf79d20f741f39325018f4df051ef39fe921b1ebe780a66184c"},
-    {file = "wrapt-1.14.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:8c0ce1e99116d5ab21355d8ebe53d9460366704ea38ae4d9f6933188f327b456"},
-    {file = "wrapt-1.14.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:e3fb1677c720409d5f671e39bac6c9e0e422584e5f518bfd50aa4cbbea02433f"},
-    {file = "wrapt-1.14.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:642c2e7a804fcf18c222e1060df25fc210b9c58db7c91416fb055897fc27e8cc"},
-    {file = "wrapt-1.14.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7b7c050ae976e286906dd3f26009e117eb000fb2cf3533398c5ad9ccc86867b1"},
-    {file = "wrapt-1.14.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ef3f72c9666bba2bab70d2a8b79f2c6d2c1a42a7f7e2b0ec83bb2f9e383950af"},
-    {file = "wrapt-1.14.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:01c205616a89d09827986bc4e859bcabd64f5a0662a7fe95e0d359424e0e071b"},
-    {file = "wrapt-1.14.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:5a0f54ce2c092aaf439813735584b9537cad479575a09892b8352fea5e988dc0"},
-    {file = "wrapt-1.14.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:2cf71233a0ed05ccdabe209c606fe0bac7379fdcf687f39b944420d2a09fdb57"},
-    {file = "wrapt-1.14.1-cp38-cp38-win32.whl", hash = "sha256:aa31fdcc33fef9eb2552cbcbfee7773d5a6792c137b359e82879c101e98584c5"},
-    {file = "wrapt-1.14.1-cp38-cp38-win_amd64.whl", hash = "sha256:d1967f46ea8f2db647c786e78d8cc7e4313dbd1b0aca360592d8027b8508e24d"},
-    {file = "wrapt-1.14.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:3232822c7d98d23895ccc443bbdf57c7412c5a65996c30442ebe6ed3df335383"},
-    {file = "wrapt-1.14.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:988635d122aaf2bdcef9e795435662bcd65b02f4f4c1ae37fbee7401c440b3a7"},
-    {file = "wrapt-1.14.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9cca3c2cdadb362116235fdbd411735de4328c61425b0aa9f872fd76d02c4e86"},
-    {file = "wrapt-1.14.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d52a25136894c63de15a35bc0bdc5adb4b0e173b9c0d07a2be9d3ca64a332735"},
-    {file = "wrapt-1.14.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:40e7bc81c9e2b2734ea4bc1aceb8a8f0ceaac7c5299bc5d69e37c44d9081d43b"},
-    {file = "wrapt-1.14.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:b9b7a708dd92306328117d8c4b62e2194d00c365f18eff11a9b53c6f923b01e3"},
-    {file = "wrapt-1.14.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:6a9a25751acb379b466ff6be78a315e2b439d4c94c1e99cb7266d40a537995d3"},
-    {file = "wrapt-1.14.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:34aa51c45f28ba7f12accd624225e2b1e5a3a45206aa191f6f9aac931d9d56fe"},
-    {file = "wrapt-1.14.1-cp39-cp39-win32.whl", hash = "sha256:dee0ce50c6a2dd9056c20db781e9c1cfd33e77d2d569f5d1d9321c641bb903d5"},
-    {file = "wrapt-1.14.1-cp39-cp39-win_amd64.whl", hash = "sha256:dee60e1de1898bde3b238f18340eec6148986da0455d8ba7848d50470a7a32fb"},
-    {file = "wrapt-1.14.1.tar.gz", hash = "sha256:380a85cf89e0e69b7cfbe2ea9f765f004ff419f34194018a6827ac0e3edfed4d"},
-]
+wrapt = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cofactr"
-version = "5.10.0"
+version = "5.11.0"
 description = "Client library for accessing Cofactr data."
 authors = ["Noah Trueblood <noah@cofactr.com>", "Riley Harrington <riley@cofactr.com>"]
 license = "MIT"
@@ -28,6 +28,7 @@ black = "^22.3.0"
 types-urllib3 = "^1.26.11"
 pylint = "^2.13.8"
 pytest = "^7.1.2"
+python-dotenv = "^0.21.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/sample.env.test
+++ b/sample.env.test
@@ -1,0 +1,2 @@
+CLIENT_ID=
+API_KEY=

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,8 +1,10 @@
 """Test GraphAPI."""
 # Standard Modules
+from pathlib import Path
 from typing import Any, Dict, List
 
 # 3rd Party Modules
+from dotenv import dotenv_values
 import pytest
 
 # Local Modules
@@ -13,6 +15,9 @@ from cofactr.schema import (
     SupplierSchemaName,
 )
 
+CONFIG = dotenv_values(Path(__file__).parent / "../.env.test")
+CLIENT_ID = CONFIG["CLIENT_ID"]
+API_KEY = CONFIG["API_KEY"]
 
 @pytest.mark.parametrize(
     "mpn",
@@ -21,7 +26,7 @@ from cofactr.schema import (
 def test_search_part(mpn: str):
     """Test searching for parts."""
 
-    graph = GraphAPI()
+    graph = GraphAPI(client_id=CLIENT_ID, api_key=API_KEY)
 
     res = graph.get_products(
         query=mpn,
@@ -42,7 +47,7 @@ def test_search_part(mpn: str):
             {
                 "id": "TRRQ3ESYFO28",
                 "mpn": "IRFH5006TRPBF",
-                "hero_image": "https://assets.cofactr.com/TRRQ3ESYFO28/part-img.jpg",
+                # "hero_image": "https://assets.cofactr.com/TRRQ3ESYFO28/part-img.jpg",
             },
         ),
         (
@@ -51,7 +56,7 @@ def test_search_part(mpn: str):
             {
                 "id": "TRRQ3ESYFO28",
                 "mpn": "IRFH5006TRPBF",
-                "hero_image": "https://assets.cofactr.com/TRRQ3ESYFO28/part-img.jpg",
+                # "hero_image": "https://assets.cofactr.com/TRRQ3ESYFO28/part-img.jpg",
             },
         ),
     ],
@@ -59,7 +64,7 @@ def test_search_part(mpn: str):
 def test_get_product(schema: ProductSchemaName, cpid: str, expected: Dict[str, Any]):
     """Test getting a product by its ID."""
 
-    graph = GraphAPI()
+    graph = GraphAPI(client_id=CLIENT_ID, api_key=API_KEY)
 
     res = graph.get_product(
         id=cpid,
@@ -107,7 +112,7 @@ def test_get_product(schema: ProductSchemaName, cpid: str, expected: Dict[str, A
 def test_get_products_by_ids(ids: List[str]):
     """Test getting parts in bulk by their IDs."""
 
-    graph = GraphAPI()
+    graph = GraphAPI(client_id=CLIENT_ID, api_key=API_KEY)
 
     res = graph.get_products_by_ids(
         ids=ids,
@@ -126,12 +131,12 @@ def test_get_products_by_ids(ids: List[str]):
 
 @pytest.mark.parametrize(
     "cpid",
-    ["IM60640MOX6H"],
+    ["CCV1F7A8UIYH"],
 )
 def test_get_offers(cpid: str):
     """Test getting offers."""
 
-    graph = GraphAPI()
+    graph = GraphAPI(client_id=CLIENT_ID, api_key=API_KEY)
 
     flagship_res = graph.get_offers(
         product_id=cpid,
@@ -144,7 +149,7 @@ def test_get_offers(cpid: str):
     logistics_res = graph.get_offers(
         product_id=cpid,
         external=False,
-        schema=OfferSchemaName.LOGISTICS,
+        schema=OfferSchemaName.LOGISTICS_V2,
     )
 
     assert logistics_res
@@ -154,7 +159,7 @@ def test_get_offers(cpid: str):
 def test_get_suppliers(query):
     """Test getting suppliers."""
 
-    graph = GraphAPI()
+    graph = GraphAPI(client_id=CLIENT_ID, api_key=API_KEY)
 
     res = graph.get_suppliers(query=query, schema=SupplierSchemaName.FLAGSHIP)
 
@@ -168,7 +173,7 @@ def test_get_suppliers(query):
 def test_get_supplier(org_id):
     """Test getting a supplier."""
 
-    graph = GraphAPI()
+    graph = GraphAPI(client_id=CLIENT_ID, api_key=API_KEY)
 
     res = graph.get_supplier(id=org_id, schema=SupplierSchemaName.FLAGSHIP)
 
@@ -190,7 +195,7 @@ def test_get_supplier(org_id):
 def test_autocomplete_orgs(query, expected_completions):
     """Test autocompleting orgs."""
 
-    graph = GraphAPI()
+    graph = GraphAPI(client_id=CLIENT_ID, api_key=API_KEY)
 
     res = graph.autocomplete_orgs(query=query, types="supplier")
 
@@ -203,7 +208,7 @@ def test_autocomplete_orgs(query, expected_completions):
 def test_get_products_by_searches(mpns):
     """Test executing a batch of product searches."""
 
-    graph = GraphAPI(default_product_schema=ProductSchemaName.FLAGSHIP_V3)
+    graph = GraphAPI(client_id=CLIENT_ID, api_key=API_KEY, default_product_schema=ProductSchemaName.FLAGSHIP_V3)
 
     mpn_to_products = graph.get_products_by_searches(queries=mpns)
 


### PR DESCRIPTION
Adds a seller schema and an offer schema, both with `rfq_email` as a field for use by the logistics team.