### PR TITLE
Feat/Add supplier fields

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "[python]": {
+        "editor.defaultFormatter": "ms-python.black-formatter"
+    },
+    "python.formatting.provider": "none"
+}

--- a/cofactr/schema/__init__.py
+++ b/cofactr/schema/__init__.py
@@ -8,8 +8,8 @@ from cofactr.helpers import identity
 from cofactr.schema.flagship import FlagshipOffer, FlagshipPart, FlagshipSeller
 from cofactr.schema.flagship_v2 import FlagshipV2Offer, FlagshipV2Part, FlagshipV2Seller
 from cofactr.schema.flagship_v3 import FlagshipV3Offer, FlagshipV3Part, FlagshipV3Seller
-from cofactr.schema.flagship_v4 import FlagshipV4Part, FlagshipV4Offer
-from cofactr.schema.flagship_v5 import FlagshipV5Part
+from cofactr.schema.flagship_v4 import FlagshipV4Part, FlagshipV4Offer, FlagshipV4Seller
+from cofactr.schema.flagship_v5 import FlagshipV5Offer, FlagshipV5Part
 from cofactr.schema.flagship_v6 import FlagshipV6Part
 from cofactr.schema.flagship_v7 import FlagshipV7Part
 from cofactr.schema.flagship_alts_v0 import FlagshipAltsV0Part
@@ -33,6 +33,7 @@ from cofactr.schema.price_solver_v3 import PriceSolverV3Part
 from cofactr.schema.price_solver_v4 import PriceSolverV4Part
 from cofactr.schema.price_solver_v5 import PriceSolverV5Part
 from cofactr.schema.price_solver_v6 import PriceSolverV6Part
+from cofactr.schema.price_solver_v7 import PriceSolverV7Part
 
 
 class ProductSchemaName(str, Enum):
@@ -63,6 +64,7 @@ class ProductSchemaName(str, Enum):
     PRICE_SOLVER_V4 = "price-solver-v4"
     PRICE_SOLVER_V5 = "price-solver-v5"
     PRICE_SOLVER_V6 = "price-solver-v6"
+    PRICE_SOLVER_V7 = "price-solver-v7"
 
 
 schema_to_product: Dict[ProductSchemaName, Callable] = {
@@ -90,6 +92,7 @@ schema_to_product: Dict[ProductSchemaName, Callable] = {
     ProductSchemaName.PRICE_SOLVER_V4: PriceSolverV4Part,
     ProductSchemaName.PRICE_SOLVER_V5: PriceSolverV5Part,
     ProductSchemaName.PRICE_SOLVER_V6: PriceSolverV6Part,
+    ProductSchemaName.PRICE_SOLVER_V7: PriceSolverV7Part,
 }
 
 
@@ -101,6 +104,7 @@ class OfferSchemaName(str, Enum):
     FLAGSHIP_V2 = "flagship-v2"
     FLAGSHIP_V3 = "flagship-v3"
     FLAGSHIP_V4 = "flagship-v4"
+    FLAGSHIP_V5 = "flagship-v5"
     LOGISTICS = "logistics"
     LOGISTICS_V2 = "logistics-v2"
 
@@ -111,6 +115,7 @@ schema_to_offer: Dict[OfferSchemaName, Callable] = {
     OfferSchemaName.FLAGSHIP_V2: FlagshipV2Offer,
     OfferSchemaName.FLAGSHIP_V3: FlagshipV3Offer,
     OfferSchemaName.FLAGSHIP_V4: FlagshipV4Offer,
+    OfferSchemaName.FLAGSHIP_V5: FlagshipV5Offer,
     OfferSchemaName.LOGISTICS: LogisticsOffer,
     OfferSchemaName.LOGISTICS_V2: LogisticsV2Offer,
 }
@@ -123,6 +128,7 @@ class OrgSchemaName(str, Enum):
     FLAGSHIP = "flagship"
     FLAGSHIP_V2 = "flagship-v2"
     FLAGSHIP_V3 = "flagship-v3"
+    FLAGSHIP_V4 = "flagship-v4"
     LOGISTICS = "logistics"
     LOGISTICS_V2 = "logistics-v2"
 
@@ -132,6 +138,7 @@ schema_to_org: Dict[OrgSchemaName, Callable] = {
     OrgSchemaName.FLAGSHIP: FlagshipSeller,
     OrgSchemaName.FLAGSHIP_V2: FlagshipV2Seller,
     OrgSchemaName.FLAGSHIP_V3: FlagshipV3Seller,
+    OrgSchemaName.FLAGSHIP_V4: FlagshipV4Seller,
     OrgSchemaName.LOGISTICS: FlagshipSeller,
     OrgSchemaName.LOGISTICS_V2: LogisticsV2Seller,
 }
@@ -144,6 +151,7 @@ class SupplierSchemaName(str, Enum):
     FLAGSHIP = "flagship"
     FLAGSHIP_V2 = "flagship-v2"
     FLAGSHIP_V3 = "flagship-v3"
+    FLAGSHIP_V4 = "flagship-v4"
     LOGISTICS = "logistics"
     LOGISTICS_V2 = "logistics-v2"
 
@@ -153,6 +161,7 @@ schema_to_supplier: Dict[SupplierSchemaName, Callable] = {
     SupplierSchemaName.FLAGSHIP: FlagshipSeller,
     SupplierSchemaName.FLAGSHIP_V2: FlagshipV2Seller,
     SupplierSchemaName.FLAGSHIP_V3: FlagshipV3Seller,
+    SupplierSchemaName.FLAGSHIP_V4: FlagshipV4Seller,
     SupplierSchemaName.LOGISTICS: FlagshipSeller,
     SupplierSchemaName.LOGISTICS_V2: LogisticsV2Seller,
 }

--- a/cofactr/schema/flagship_v4/__init__.py
+++ b/cofactr/schema/flagship_v4/__init__.py
@@ -1,2 +1,3 @@
 from .part import Part as FlagshipV4Part
 from .offer import Offer as FlagshipV4Offer
+from .seller import Seller as FlagshipV4Seller

--- a/cofactr/schema/flagship_v4/seller.py
+++ b/cofactr/schema/flagship_v4/seller.py
@@ -1,0 +1,16 @@
+"""Part seller class."""
+# Standard Modules
+from dataclasses import dataclass
+from typing import List, Optional
+
+# Local Modules
+from cofactr.schema.flagship_v3.seller import Seller as FlagshipV3Seller
+
+
+@dataclass
+class Seller(FlagshipV3Seller):
+    """Part seller."""
+
+    deprecated_ids: List[str]
+    convenience_return_window: Optional[int]  # Days.
+    scheduled_release_period: Optional[int]  # Months.

--- a/cofactr/schema/flagship_v5/__init__.py
+++ b/cofactr/schema/flagship_v5/__init__.py
@@ -1,1 +1,2 @@
+from .offer import Offer as FlagshipV5Offer
 from .part import Part as FlagshipV5Part

--- a/cofactr/schema/flagship_v5/offer.py
+++ b/cofactr/schema/flagship_v5/offer.py
@@ -1,0 +1,22 @@
+"""Part offer class."""
+# Standard Modules
+from dataclasses import dataclass
+from typing import Optional
+
+# Local Modules
+from cofactr.schema.flagship_v4.offer import Offer as FlagshipV4Offer
+from cofactr.schema.flagship_v4.seller import Seller as FlagshipV4Seller
+
+
+@dataclass
+class Offer(FlagshipV4Offer):
+    """Part offer."""
+
+    seller: FlagshipV4Seller
+    convenience_return_window: Optional[int]  # Days.
+    scheduled_release_period: Optional[int]  # Months.
+
+    def __post_init__(self):
+        """Convert types."""
+
+        self.seller = FlagshipV4Seller(**self.seller)  # pylint: disable=not-a-mapping

--- a/cofactr/schema/price_solver_v7/__init__.py
+++ b/cofactr/schema/price_solver_v7/__init__.py
@@ -1,0 +1,1 @@
+from .part import Part as PriceSolverV7Part

--- a/cofactr/schema/price_solver_v7/part.py
+++ b/cofactr/schema/price_solver_v7/part.py
@@ -1,0 +1,21 @@
+"""Part class."""
+# Standard Modules
+from dataclasses import dataclass
+from typing import List
+
+# Local Modules
+from cofactr.schema.flagship_v5.offer import Offer as FlagshipV5Offer
+from cofactr.schema.flagship_v7.part import Part as FlagshipV7Part
+
+
+@dataclass
+class Part(FlagshipV7Part):
+    """Part."""
+
+    offers: List[FlagshipV5Offer]
+
+    def __post_init__(self):
+        """Post initialization."""
+
+        self.mfg = self.mfr
+        self.offers = [FlagshipV5Offer(**offer) for offer in self.offers]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cofactr"
-version = "5.28.0"
+version = "5.29.0"
 description = "Client library for accessing Cofactr data."
 authors = ["Joseph Sayad <joseph@cofactr.com>", "Noah Trueblood <noah@cofactr.com>", "Riley Harrington <riley@cofactr.com>"]
 license = "MIT"

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -132,7 +132,7 @@ def test_get_product(schema: ProductSchemaName, cpid: str, expected: Dict[str, A
                 "XXNGAHF7HD8S",
                 "TRCAHGIXODI7",
             ],
-            ProductSchemaName.PRICE_SOLVER_V6,
+            ProductSchemaName.PRICE_SOLVER_V7,
         ),
         (
             [
@@ -168,7 +168,7 @@ def test_get_offers(cpid: str):
     flagship_res = graph.get_offers(
         product_id=cpid,
         external=False,
-        schema=OfferSchemaName.FLAGSHIP_V3,
+        schema=OfferSchemaName.FLAGSHIP_V5,
     )
 
     assert flagship_res
@@ -188,7 +188,7 @@ def test_get_suppliers(query):
 
     graph = GraphAPI(client_id=CLIENT_ID, api_key=API_KEY)
 
-    res = graph.get_suppliers(query=query, schema=SupplierSchemaName.FLAGSHIP_V2)
+    res = graph.get_suppliers(query=query, schema=SupplierSchemaName.FLAGSHIP_V4)
 
     data = res["data"]
     assert data
@@ -202,7 +202,7 @@ def test_get_supplier(org_id):
 
     graph = GraphAPI(client_id=CLIENT_ID, api_key=API_KEY)
 
-    res = graph.get_supplier(id=org_id, schema=SupplierSchemaName.FLAGSHIP_V2)
+    res = graph.get_supplier(id=org_id, schema=SupplierSchemaName.FLAGSHIP_V4)
 
     assert res["data"].id == org_id
 
@@ -287,7 +287,7 @@ def test_get_suppliers_by_ids(ids):
     graph = GraphAPI(
         client_id=CLIENT_ID,
         api_key=API_KEY,
-        default_supplier_schema=SupplierSchemaName.FLAGSHIP_V2,
+        default_supplier_schema=SupplierSchemaName.FLAGSHIP_V4,
     )
 
     id_to_supplier = graph.get_suppliers_by_ids(ids=ids)
@@ -324,7 +324,7 @@ def test_get_canonical_product_ids(ids, expected_id_to_canonical_id):
     graph = GraphAPI(
         client_id=CLIENT_ID,
         api_key=API_KEY,
-        default_supplier_schema=SupplierSchemaName.FLAGSHIP_V2,
+        default_supplier_schema=SupplierSchemaName.FLAGSHIP_V4,
     )
 
     actual_id_to_canonical_id = graph.get_canonical_product_ids(ids=ids)
@@ -370,7 +370,7 @@ def test_set_custom_product_ids(id_to_custom_id, owner_id):
     graph = GraphAPI(
         client_id=CLIENT_ID,
         api_key=API_KEY,
-        default_supplier_schema=SupplierSchemaName.FLAGSHIP_V2,
+        default_supplier_schema=SupplierSchemaName.FLAGSHIP_V4,
     )
 
     graph.set_custom_product_ids(id_to_custom_id=id_to_custom_id, owner_id=owner_id)


### PR DESCRIPTION
Adds `deprecated_ids`, `convenience_return_window`, and `scheduled_release_period` to the flagship supplier schema and propagates that change to dependent schemas (flagship offers and price solver). In addition, these fields are added as top-level fields to the flagship offer schema because in the future they're likely to be offer-specific, rather than solely based on the supplier-level value.