### PR TITLE
Feat/Add orders

### DIFF
--- a/cofactr/graph.py
+++ b/cofactr/graph.py
@@ -1175,7 +1175,7 @@ class GraphAPI:  # pylint: disable=too-many-instance-attributes
             schema: Response schema.
             timeout: Time to wait (in seconds) for the server to issue a response.
             filtering: Filter orders.
-                Example: `[{"field":"id","operator":"IN","value":["digikey:12345678"]}]`.
+                Example: `[{"field":"id","operator":"IN","value":["622fb450e4c292d8287b0af5:12345678"]}]`.
             owner_id: Specifies which private data to access.
         """
 

--- a/cofactr/graph.py
+++ b/cofactr/graph.py
@@ -23,6 +23,7 @@ from tenacity import (
 from cofactr.helpers import parse_entities
 from cofactr.schema import (
     OfferSchemaName,
+    OrderSchemaName,
     OrgSchemaName,
     ProductSchemaName,
     SupplierSchemaName,
@@ -34,6 +35,7 @@ from cofactr.schema import (
 from cofactr.schema.types import Completion, PartInV0, PartialPartInV0
 
 Protocol = Literal["http", "https"]
+
 
 class SearchStrategy(str, Enum):
     """Search strategy."""
@@ -213,15 +215,16 @@ class GraphAPI:  # pylint: disable=too-many-instance-attributes
         protocol: Optional[Protocol] = PROTOCOL,
         host: Optional[str] = HOST,
         default_product_schema: ProductSchemaName = ProductSchemaName.FLAGSHIP,
+        default_order_schema: OrderSchemaName = OrderSchemaName.FLAGSHIP,
         default_org_schema: OrgSchemaName = OrgSchemaName.FLAGSHIP,
         default_offer_schema: OfferSchemaName = OfferSchemaName.FLAGSHIP,
         default_supplier_schema: SupplierSchemaName = SupplierSchemaName.FLAGSHIP,
         client_id: Optional[str] = None,
         api_key: Optional[str] = None,
     ):
-
         self.url = f"{protocol}://{host}"
         self.default_product_schema = default_product_schema
+        self.default_order_schema = default_order_schema
         self.default_org_schema = default_org_schema
         self.default_offer_schema = default_offer_schema
         self.default_supplier_schema = default_supplier_schema
@@ -442,7 +445,7 @@ class GraphAPI:  # pylint: disable=too-many-instance-attributes
 
         if not ids:
             return {}
-    
+
         batch_size = 250
 
         if not schema:
@@ -959,7 +962,7 @@ class GraphAPI:  # pylint: disable=too-many-instance-attributes
         )
 
         res.raise_for_status()
-    
+
     @retry(
         reraise=retry_settings.reraise,
         retry=retry_settings.retry,
@@ -1000,7 +1003,6 @@ class GraphAPI:  # pylint: disable=too-many-instance-attributes
         )
 
         res.raise_for_status()
-
 
     @retry(
         reraise=retry_settings.reraise,
@@ -1157,3 +1159,31 @@ class GraphAPI:  # pylint: disable=too-many-instance-attributes
         )
 
         return res_json
+
+    @retry(
+        reraise=retry_settings.reraise,
+        retry=retry_settings.retry,
+        stop=retry_settings.stop,
+        wait=retry_settings.wait,
+    )
+    def get_orders(
+        self,
+        schema: Optional[OrderSchemaName] = None,
+        timeout: Optional[int] = None,
+        filtering: Optional[List[Dict]] = None,
+        owner_id: Optional[str] = None,
+    ):
+        """Get orders.
+
+        Args:
+            schema: Response schema.
+            timeout: Time to wait (in seconds) for the server to issue a response.
+            filtering: Filter suppliers.
+                Example: `[{"field":"id","operator":"IN","value":["622fb450e4c292d8287b0af5"]}]`.
+            owner_id: Specifies which private data to access.
+        """
+
+        if not schema:
+            schema = self.default_order_schema
+
+        return

--- a/cofactr/graph.py
+++ b/cofactr/graph.py
@@ -467,9 +467,7 @@ class GraphAPI:  # pylint: disable=too-many-instance-attributes
             for batched_ids in batched(ids, n=_MAX_BATCH_SIZE)
         ]
 
-        products_data = list(
-            flatten([products["data"] for products in batched_products])
-        )
+        products_data = list(flatten([res["data"] for res in batched_products]))
 
         id_to_product = parse_entities(
             ids=ids,
@@ -1246,7 +1244,7 @@ class GraphAPI:  # pylint: disable=too-many-instance-attributes
             for batched_ids in batched(ids, n=_MAX_BATCH_SIZE)
         ]
 
-        orders_data = list(flatten([products["data"] for products in batched_orders]))
+        orders_data = list(flatten([res["data"] for res in batched_orders]))
 
         # All order schemas have `id` field.
         return {order.id: order for order in orders_data}

--- a/cofactr/schema/__init__.py
+++ b/cofactr/schema/__init__.py
@@ -14,8 +14,8 @@ from cofactr.schema.flagship import (
 from cofactr.schema.flagship_v2 import FlagshipV2Offer, FlagshipV2Part, FlagshipV2Seller
 from cofactr.schema.flagship_v3 import FlagshipV3Offer, FlagshipV3Part, FlagshipV3Seller
 from cofactr.schema.flagship_v4 import FlagshipV4Part, FlagshipV4Offer, FlagshipV4Seller
-from cofactr.schema.flagship_v5 import FlagshipV5Offer, FlagshipV5Part
-from cofactr.schema.flagship_v6 import FlagshipV6Part
+from cofactr.schema.flagship_v5 import FlagshipV5Offer, FlagshipV5Part, FlagshipV5Seller
+from cofactr.schema.flagship_v6 import FlagshipV6Offer, FlagshipV6Part
 from cofactr.schema.flagship_v7 import FlagshipV7Part
 from cofactr.schema.flagship_alts_v0 import FlagshipAltsV0Part
 from cofactr.schema.flagship_cache_v0 import FlagshipCacheV0Part
@@ -39,6 +39,7 @@ from cofactr.schema.price_solver_v4 import PriceSolverV4Part
 from cofactr.schema.price_solver_v5 import PriceSolverV5Part
 from cofactr.schema.price_solver_v6 import PriceSolverV6Part
 from cofactr.schema.price_solver_v7 import PriceSolverV7Part
+from cofactr.schema.price_solver_v8 import PriceSolverV8Part
 
 
 class ProductSchemaName(str, Enum):
@@ -70,6 +71,7 @@ class ProductSchemaName(str, Enum):
     PRICE_SOLVER_V5 = "price-solver-v5"
     PRICE_SOLVER_V6 = "price-solver-v6"
     PRICE_SOLVER_V7 = "price-solver-v7"
+    PRICE_SOLVER_V8 = "price-solver-v8"
 
 
 schema_to_product: Dict[ProductSchemaName, Callable] = {
@@ -98,6 +100,7 @@ schema_to_product: Dict[ProductSchemaName, Callable] = {
     ProductSchemaName.PRICE_SOLVER_V5: PriceSolverV5Part,
     ProductSchemaName.PRICE_SOLVER_V6: PriceSolverV6Part,
     ProductSchemaName.PRICE_SOLVER_V7: PriceSolverV7Part,
+    ProductSchemaName.PRICE_SOLVER_V8: PriceSolverV8Part,
 }
 
 
@@ -110,6 +113,7 @@ class OfferSchemaName(str, Enum):
     FLAGSHIP_V3 = "flagship-v3"
     FLAGSHIP_V4 = "flagship-v4"
     FLAGSHIP_V5 = "flagship-v5"
+    FLAGSHIP_V6 = "flagship-v6"
     LOGISTICS = "logistics"
     LOGISTICS_V2 = "logistics-v2"
 
@@ -121,6 +125,7 @@ schema_to_offer: Dict[OfferSchemaName, Callable] = {
     OfferSchemaName.FLAGSHIP_V3: FlagshipV3Offer,
     OfferSchemaName.FLAGSHIP_V4: FlagshipV4Offer,
     OfferSchemaName.FLAGSHIP_V5: FlagshipV5Offer,
+    OfferSchemaName.FLAGSHIP_V6: FlagshipV6Offer,
     OfferSchemaName.LOGISTICS: LogisticsOffer,
     OfferSchemaName.LOGISTICS_V2: LogisticsV2Offer,
 }
@@ -134,6 +139,7 @@ class OrgSchemaName(str, Enum):
     FLAGSHIP_V2 = "flagship-v2"
     FLAGSHIP_V3 = "flagship-v3"
     FLAGSHIP_V4 = "flagship-v4"
+    FLAGSHIP_V5 = "flagship-v5"
     LOGISTICS = "logistics"
     LOGISTICS_V2 = "logistics-v2"
 
@@ -144,6 +150,7 @@ schema_to_org: Dict[OrgSchemaName, Callable] = {
     OrgSchemaName.FLAGSHIP_V2: FlagshipV2Seller,
     OrgSchemaName.FLAGSHIP_V3: FlagshipV3Seller,
     OrgSchemaName.FLAGSHIP_V4: FlagshipV4Seller,
+    OrgSchemaName.FLAGSHIP_V5: FlagshipV5Seller,
     OrgSchemaName.LOGISTICS: FlagshipSeller,
     OrgSchemaName.LOGISTICS_V2: LogisticsV2Seller,
 }
@@ -157,6 +164,7 @@ class SupplierSchemaName(str, Enum):
     FLAGSHIP_V2 = "flagship-v2"
     FLAGSHIP_V3 = "flagship-v3"
     FLAGSHIP_V4 = "flagship-v4"
+    FLAGSHIP_V5 = "flagship-v5"
     LOGISTICS = "logistics"
     LOGISTICS_V2 = "logistics-v2"
 
@@ -167,6 +175,7 @@ schema_to_supplier: Dict[SupplierSchemaName, Callable] = {
     SupplierSchemaName.FLAGSHIP_V2: FlagshipV2Seller,
     SupplierSchemaName.FLAGSHIP_V3: FlagshipV3Seller,
     SupplierSchemaName.FLAGSHIP_V4: FlagshipV4Seller,
+    SupplierSchemaName.FLAGSHIP_V5: FlagshipV5Seller,
     SupplierSchemaName.LOGISTICS: FlagshipSeller,
     SupplierSchemaName.LOGISTICS_V2: LogisticsV2Seller,
 }

--- a/cofactr/schema/__init__.py
+++ b/cofactr/schema/__init__.py
@@ -5,7 +5,12 @@ from typing import Callable, Dict
 
 # Local Modules
 from cofactr.helpers import identity
-from cofactr.schema.flagship import FlagshipOffer, FlagshipPart, FlagshipSeller
+from cofactr.schema.flagship import (
+    FlagshipOffer,
+    FlagshipOrderStatus,
+    FlagshipPart,
+    FlagshipSeller,
+)
 from cofactr.schema.flagship_v2 import FlagshipV2Offer, FlagshipV2Part, FlagshipV2Seller
 from cofactr.schema.flagship_v3 import FlagshipV3Offer, FlagshipV3Part, FlagshipV3Seller
 from cofactr.schema.flagship_v4 import FlagshipV4Part, FlagshipV4Offer, FlagshipV4Seller
@@ -164,4 +169,15 @@ schema_to_supplier: Dict[SupplierSchemaName, Callable] = {
     SupplierSchemaName.FLAGSHIP_V4: FlagshipV4Seller,
     SupplierSchemaName.LOGISTICS: FlagshipSeller,
     SupplierSchemaName.LOGISTICS_V2: LogisticsV2Seller,
+}
+
+
+class OrderSchemaName(str, Enum):
+    """Order schema name."""
+
+    FLAGSHIP = "flagship"
+
+
+schema_to_order: Dict[OrderSchemaName, Callable] = {
+    OrderSchemaName.FLAGSHIP: FlagshipOrderStatus,
 }

--- a/cofactr/schema/flagship/__init__.py
+++ b/cofactr/schema/flagship/__init__.py
@@ -1,3 +1,4 @@
 from .offer import Offer as FlagshipOffer
+from .order import OrderStatus as FlagshipOrderStatus
 from .part import Part as FlagshipPart
 from .seller import Seller as FlagshipSeller

--- a/cofactr/schema/flagship/order.py
+++ b/cofactr/schema/flagship/order.py
@@ -34,8 +34,8 @@ class OrderStatusLine:
     quantity_shipped: Optional[int]
     quantity_backordered: Optional[int]
     country_of_origin: Optional[str]
-    backorder_schedules: List[ScheduledRelease]
-    schedules: List[ScheduledRelease]
+    backorder_schedule: List[ScheduledRelease]
+    schedule: List[ScheduledRelease]
 
     def __post_init__(self):
         """Convert types."""

--- a/cofactr/schema/flagship/order.py
+++ b/cofactr/schema/flagship/order.py
@@ -1,0 +1,101 @@
+"""Order class."""
+# pylint: disable=not-a-mapping
+# Standard Modules
+from dataclasses import dataclass
+from typing import List, Optional
+
+
+@dataclass
+class Error:
+    """Error."""
+
+    code: Optional[str]
+    message: Optional[str]
+    name: Optional[str]
+
+
+@dataclass
+class ScheduledRelease:
+    """Scheduled release."""
+
+    scheduled_date: Optional[str]
+    scheduled_quantity: Optional[int]
+
+
+@dataclass
+class OrderStatusLine:
+    """Order status line."""
+
+    line_id: str
+    customer_reference: Optional[str]
+    cofactr_product_id: Optional[str]
+    seller_product_id: Optional[str]
+    quantity_ordered: Optional[int]
+    quantity_shipped: Optional[int]
+    quantity_backordered: Optional[int]
+    country_of_origin: Optional[str]
+    backorder_schedules: List[ScheduledRelease]
+    schedules: List[ScheduledRelease]
+
+    def __post_init__(self):
+        """Convert types."""
+
+        self.backorder_schedule = [
+            ScheduledRelease(**schedule) for schedule in self.backorder_schedule
+        ]
+        self.schedule = [
+            ScheduledRelease(**schedule) for schedule in self.backorder_schedule
+        ]
+
+
+@dataclass
+class PackageItem:
+    """Package item."""
+
+    # Line ID of item being shipped.
+    line_id: str
+    # Quantity in package.
+    quantity: Optional[int]
+
+
+@dataclass
+class PackageDetail:
+    """Package detail."""
+
+    items: List[PackageItem]
+    tracking_url: Optional[str]
+    tracking_number: Optional[str]
+    # Name of carrier that will deliver the package.
+    carrier_name: Optional[str]
+    # Method to be used for shipping the order.
+    shipping_method: Optional[str]
+
+    def __post_init__(self):
+        """Convert types."""
+
+        self.items = [PackageItem(**item) for item in self.items]
+
+
+@dataclass
+class OrderStatus:  # pylint: disable=too-many-instance-attributes
+    """Order status."""
+
+    # Unique Cofactr-defined identifier representing the order.
+    id: str
+    # Identifier representing the order in seller's order management system.
+    seller_order_id: str
+    # Errors associated with the order.
+    errors: List[Error]
+    package_details: List[PackageDetail]
+    order_status_lines: List[OrderStatusLine]
+
+    def __post_init__(self):
+        """Convert types."""
+
+        self.errors = [Error(**error) for error in self.errors]
+        self.package_details = [
+            PackageDetail(**detail) for detail in self.package_details
+        ]
+        self.order_status_lines = [
+            OrderStatusLine(**line) for line in self.order_status_lines
+        ]

--- a/cofactr/schema/flagship/order.py
+++ b/cofactr/schema/flagship/order.py
@@ -43,9 +43,7 @@ class OrderStatusLine:
         self.backorder_schedule = [
             ScheduledRelease(**schedule) for schedule in self.backorder_schedule
         ]
-        self.schedule = [
-            ScheduledRelease(**schedule) for schedule in self.backorder_schedule
-        ]
+        self.schedule = [ScheduledRelease(**schedule) for schedule in self.schedule]
 
 
 @dataclass

--- a/cofactr/schema/flagship_v5/__init__.py
+++ b/cofactr/schema/flagship_v5/__init__.py
@@ -1,2 +1,3 @@
 from .offer import Offer as FlagshipV5Offer
 from .part import Part as FlagshipV5Part
+from .seller import Seller as FlagshipV5Seller

--- a/cofactr/schema/flagship_v5/seller.py
+++ b/cofactr/schema/flagship_v5/seller.py
@@ -1,0 +1,16 @@
+"""Part seller class."""
+# Standard Modules
+from dataclasses import dataclass
+
+# Local Modules
+from cofactr.schema.flagship_v4.seller import Seller as FlagshipV4Seller
+
+
+@dataclass
+class Seller(FlagshipV4Seller):
+    """Part seller."""
+
+    # Does the API support placing new orders for this seller?
+    is_api_ordering_supported: bool
+    # Does the API support checking the status of existing orders for this seller?
+    is_api_order_status_supported: bool

--- a/cofactr/schema/flagship_v6/__init__.py
+++ b/cofactr/schema/flagship_v6/__init__.py
@@ -1,1 +1,2 @@
+from .offer import Offer as FlagshipV6Offer
 from .part import Part as FlagshipV6Part

--- a/cofactr/schema/flagship_v6/offer.py
+++ b/cofactr/schema/flagship_v6/offer.py
@@ -1,0 +1,19 @@
+"""Part offer class."""
+# Standard Modules
+from dataclasses import dataclass
+
+# Local Modules
+from cofactr.schema.flagship_v5.offer import Offer as FlagshipV5Offer
+from cofactr.schema.flagship_v5.seller import Seller as FlagshipV5Seller
+
+
+@dataclass
+class Offer(FlagshipV5Offer):
+    """Part offer."""
+
+    seller: FlagshipV5Seller
+
+    def __post_init__(self):
+        """Convert types."""
+
+        self.seller = FlagshipV5Seller(**self.seller)  # pylint: disable=not-a-mapping

--- a/cofactr/schema/price_solver_v8/__init__.py
+++ b/cofactr/schema/price_solver_v8/__init__.py
@@ -1,0 +1,1 @@
+from .part import Part as PriceSolverV8Part

--- a/cofactr/schema/price_solver_v8/part.py
+++ b/cofactr/schema/price_solver_v8/part.py
@@ -1,0 +1,21 @@
+"""Part class."""
+# Standard Modules
+from dataclasses import dataclass
+from typing import List
+
+# Local Modules
+from cofactr.schema.flagship_v6.offer import Offer as FlagshipV6Offer
+from cofactr.schema.flagship_v7.part import Part as FlagshipV7Part
+
+
+@dataclass
+class Part(FlagshipV7Part):
+    """Part."""
+
+    offers: List[FlagshipV6Offer]
+
+    def __post_init__(self):
+        """Post initialization."""
+
+        self.mfg = self.mfr
+        self.offers = [FlagshipV6Offer(**offer) for offer in self.offers]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cofactr"
-version = "5.29.1"
+version = "5.30.0"
 description = "Client library for accessing Cofactr data."
 authors = ["Joseph Sayad <joseph@cofactr.com>", "Noah Trueblood <noah@cofactr.com>", "Riley Harrington <riley@cofactr.com>"]
 license = "MIT"

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -386,7 +386,7 @@ def test_set_custom_product_ids(id_to_custom_id, owner_id):
     ],
 )
 def test_get_orders(filtering, expected_order_ids):
-    """Test setting custom product IDs."""
+    """Test getting orders."""
 
     graph = GraphAPI(
         client_id=CLIENT_ID,
@@ -411,7 +411,7 @@ def test_get_orders(filtering, expected_order_ids):
     ],
 )
 def test_get_orders_by_ids(ids, expected_order_ids):
-    """Test setting custom product IDs."""
+    """Test gettings orders from Cofactr order IDs."""
 
     graph = GraphAPI(
         client_id=CLIENT_ID,

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -374,3 +374,55 @@ def test_set_custom_product_ids(id_to_custom_id, owner_id):
     )
 
     graph.set_custom_product_ids(id_to_custom_id=id_to_custom_id, owner_id=owner_id)
+
+
+@pytest.mark.parametrize(
+    "filtering,expected_order_ids",
+    [
+        (
+            [{"field": "id", "operator": "IN", "value": ["digikey:82103877"]}],
+            ["digikey:82103877"],
+        ),
+    ],
+)
+def test_get_orders(filtering, expected_order_ids):
+    """Test setting custom product IDs."""
+
+    graph = GraphAPI(
+        client_id=CLIENT_ID,
+        api_key=API_KEY,
+    )
+
+    res = graph.get_orders(filtering=filtering)
+
+    actual_orders = res["data"]
+    actual_order_ids = [order.id for order in actual_orders]
+
+    assert expected_order_ids == actual_order_ids
+
+
+@pytest.mark.parametrize(
+    "ids,expected_order_ids",
+    [
+        (
+            ["digikey:82103877"],
+            ["digikey:82103877"],
+        ),
+    ],
+)
+def test_get_orders_by_ids(ids, expected_order_ids):
+    """Test setting custom product IDs."""
+
+    graph = GraphAPI(
+        client_id=CLIENT_ID,
+        api_key=API_KEY,
+    )
+
+    id_to_order = graph.get_orders_by_ids(ids=ids)
+
+    assert expected_order_ids == list(id_to_order.keys())
+
+    for expected_order_id in expected_order_ids:
+        order = id_to_order[expected_order_id]
+
+        assert order.id == expected_order_id

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -132,7 +132,7 @@ def test_get_product(schema: ProductSchemaName, cpid: str, expected: Dict[str, A
                 "XXNGAHF7HD8S",
                 "TRCAHGIXODI7",
             ],
-            ProductSchemaName.PRICE_SOLVER_V7,
+            ProductSchemaName.PRICE_SOLVER_V8,
         ),
         (
             [
@@ -168,7 +168,7 @@ def test_get_offers(cpid: str):
     flagship_res = graph.get_offers(
         product_id=cpid,
         external=False,
-        schema=OfferSchemaName.FLAGSHIP_V5,
+        schema=OfferSchemaName.FLAGSHIP_V6,
     )
 
     assert flagship_res
@@ -188,7 +188,7 @@ def test_get_suppliers(query):
 
     graph = GraphAPI(client_id=CLIENT_ID, api_key=API_KEY)
 
-    res = graph.get_suppliers(query=query, schema=SupplierSchemaName.FLAGSHIP_V4)
+    res = graph.get_suppliers(query=query, schema=SupplierSchemaName.FLAGSHIP_V5)
 
     data = res["data"]
     assert data
@@ -202,7 +202,7 @@ def test_get_supplier(org_id):
 
     graph = GraphAPI(client_id=CLIENT_ID, api_key=API_KEY)
 
-    res = graph.get_supplier(id=org_id, schema=SupplierSchemaName.FLAGSHIP_V4)
+    res = graph.get_supplier(id=org_id, schema=SupplierSchemaName.FLAGSHIP_V5)
 
     assert res["data"].id == org_id
 
@@ -287,7 +287,7 @@ def test_get_suppliers_by_ids(ids):
     graph = GraphAPI(
         client_id=CLIENT_ID,
         api_key=API_KEY,
-        default_supplier_schema=SupplierSchemaName.FLAGSHIP_V4,
+        default_supplier_schema=SupplierSchemaName.FLAGSHIP_V5,
     )
 
     id_to_supplier = graph.get_suppliers_by_ids(ids=ids)
@@ -324,7 +324,7 @@ def test_get_canonical_product_ids(ids, expected_id_to_canonical_id):
     graph = GraphAPI(
         client_id=CLIENT_ID,
         api_key=API_KEY,
-        default_supplier_schema=SupplierSchemaName.FLAGSHIP_V4,
+        default_supplier_schema=SupplierSchemaName.FLAGSHIP_V5,
     )
 
     actual_id_to_canonical_id = graph.get_canonical_product_ids(ids=ids)
@@ -370,7 +370,7 @@ def test_set_custom_product_ids(id_to_custom_id, owner_id):
     graph = GraphAPI(
         client_id=CLIENT_ID,
         api_key=API_KEY,
-        default_supplier_schema=SupplierSchemaName.FLAGSHIP_V4,
+        default_supplier_schema=SupplierSchemaName.FLAGSHIP_V5,
     )
 
     graph.set_custom_product_ids(id_to_custom_id=id_to_custom_id, owner_id=owner_id)

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -380,8 +380,14 @@ def test_set_custom_product_ids(id_to_custom_id, owner_id):
     "filtering,expected_order_ids",
     [
         (
-            [{"field": "id", "operator": "IN", "value": ["digikey:82103877"]}],
-            ["digikey:82103877"],
+            [
+                {
+                    "field": "id",
+                    "operator": "IN",
+                    "value": ["622fb450e4c292d8287b0af5:82103877"],
+                }
+            ],
+            ["622fb450e4c292d8287b0af5:82103877"],
         ),
     ],
 )
@@ -405,8 +411,8 @@ def test_get_orders(filtering, expected_order_ids):
     "ids,expected_order_ids",
     [
         (
-            ["digikey:82103877"],
-            ["digikey:82103877"],
+            ["622fb450e4c292d8287b0af5:82103877"],
+            ["622fb450e4c292d8287b0af5:82103877"],
         ),
     ],
 )


### PR DESCRIPTION
Adds an order schema and two methods for fetching.

- `FlagshipOrderStatus` schema focuses on detailing the progress of an order.
- `get_orders_by_ids` for high-level order fetching using a list of Cofactr IDs.
- `get_orders` method wraps the KB API's `GET /orders/` endpoint.

Also, the flagship seller schema is extended with fields that indicate what order functionality the API supports for the seller.
