### PR TITLE
Feat/Add `flagship-cache-v5` schema (KB-943)

### DIFF
--- a/cofactr/schema/__init__.py
+++ b/cofactr/schema/__init__.py
@@ -23,6 +23,7 @@ from cofactr.schema.flagship_cache_v1 import FlagshipCacheV1Part
 from cofactr.schema.flagship_cache_v2 import FlagshipCacheV2Part
 from cofactr.schema.flagship_cache_v3 import FlagshipCacheV3Part
 from cofactr.schema.flagship_cache_v4 import FlagshipCacheV4Part
+from cofactr.schema.flagship_cache_v5 import FlagshipCacheV5Part
 from cofactr.schema.logistics import LogisticsOffer, LogisticsPart
 from cofactr.schema.logistics_v2 import (
     LogisticsV2Part,
@@ -59,6 +60,7 @@ class ProductSchemaName(str, Enum):
     FLAGSHIP_CACHE_V2 = "flagship-cache-v2"
     FLAGSHIP_CACHE_V3 = "flagship-cache-v3"
     FLAGSHIP_CACHE_V4 = "flagship-cache-v4"
+    FLAGSHIP_CACHE_V5 = "flagship-cache-v5"
     LOGISTICS = "logistics"
     LOGISTICS_V2 = "logistics-v2"
     LOGISTICS_V3 = "logistics-v3"
@@ -88,6 +90,7 @@ schema_to_product: Dict[ProductSchemaName, Callable] = {
     ProductSchemaName.FLAGSHIP_CACHE_V2: FlagshipCacheV2Part,
     ProductSchemaName.FLAGSHIP_CACHE_V3: FlagshipCacheV3Part,
     ProductSchemaName.FLAGSHIP_CACHE_V4: FlagshipCacheV4Part,
+    ProductSchemaName.FLAGSHIP_CACHE_V5: FlagshipCacheV5Part,
     ProductSchemaName.LOGISTICS: LogisticsPart,
     ProductSchemaName.LOGISTICS_V2: LogisticsV2Part,
     ProductSchemaName.LOGISTICS_V3: LogisticsV3Part,

--- a/cofactr/schema/flagship_cache_v5/__init__.py
+++ b/cofactr/schema/flagship_cache_v5/__init__.py
@@ -1,0 +1,1 @@
+from .part import Part as FlagshipCacheV5Part

--- a/cofactr/schema/flagship_cache_v5/part.py
+++ b/cofactr/schema/flagship_cache_v5/part.py
@@ -1,6 +1,7 @@
 """Part class."""
 # Standard Modules
 from dataclasses import dataclass
+from typing import Optional
 
 # Local Modules
 from cofactr.schema.flagship_cache_v4.part import Part as FlagshipCacheV4Part
@@ -10,4 +11,4 @@ from cofactr.schema.flagship_cache_v4.part import Part as FlagshipCacheV4Part
 class Part(FlagshipCacheV4Part):  # pylint: disable=too-many-instance-attributes
     """Part."""
 
-    msl: str
+    msl: Optional[str]

--- a/cofactr/schema/flagship_cache_v5/part.py
+++ b/cofactr/schema/flagship_cache_v5/part.py
@@ -1,0 +1,13 @@
+"""Part class."""
+# Standard Modules
+from dataclasses import dataclass
+
+# Local Modules
+from cofactr.schema.flagship_cache_v4.part import Part as FlagshipCacheV4Part
+
+
+@dataclass
+class Part(FlagshipCacheV4Part):  # pylint: disable=too-many-instance-attributes
+    """Part."""
+
+    msl: str

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cofactr"
-version = "5.30.0"
+version = "5.31.0"
 description = "Client library for accessing Cofactr data."
 authors = ["Joseph Sayad <joseph@cofactr.com>", "Noah Trueblood <noah@cofactr.com>", "Riley Harrington <riley@cofactr.com>"]
 license = "MIT"

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -125,7 +125,7 @@ def test_get_product(schema: ProductSchemaName, cpid: str, expected: Dict[str, A
                 "INKADXLYWJQC",
                 "TRGC72NRRA4W",
             ],
-            ProductSchemaName.FLAGSHIP_CACHE_V4,
+            ProductSchemaName.FLAGSHIP_CACHE_V5,
         ),
         (
             [


### PR DESCRIPTION
## Summary

Adds `flagship-cache-v5 schema`, extending v4 with MSL.

## How did you test this change?

1. Ran `test_graph.py` successfully.

2. Used the SDK to get a product by ID (i.e. `COEJDELJFLH9`) with MSL data:

<img width="1147" alt="Product" src="https://github.com/Cofactr/cofactr-client/assets/12674658/e83c4511-37a6-4350-8f77-e489c79e6914">
