### PR TITLE
Feat/Add order preset

### DIFF
--- a/cofactr/schema/types.py
+++ b/cofactr/schema/types.py
@@ -1,6 +1,6 @@
 """Types for use in schema definitions."""
 # Standard Modules
-from typing import Any, List, Literal, Optional, TypedDict
+from typing import Any, Dict, List, Literal, Optional, TypedDict
 from typing_extensions import NotRequired
 
 
@@ -166,8 +166,8 @@ class OrderInV0(TypedDict):
     seller_id: str
     # Purchase order number.
     po_number: str
-    buyer_contact: ContactV0
-    shipping_contact: ContactV0
+    buyer_contact: NotRequired[ContactV0]
+    shipping_contact: NotRequired[ContactV0]
     # Billing account ID (Example: Digi-Key Net Terms Billing account number). If it is `None`
     # or not provided, the fall back will be the default set up in integration-wide configuration.
     billing_account_id: NotRequired[Optional[str]]
@@ -177,6 +177,9 @@ class OrderInV0(TypedDict):
     # Shipping methods in order of preference (Example: `["FedEx Ground"]`).
     shipping_methods: List[str]
     order_lines: List[OrderLineInV0]
+
+    preset_id: NotRequired[str]
+    preset_args: NotRequired[Dict]
 
 
 class PricePoint(TypedDict):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cofactr"
-version = "5.36.0"
+version = "5.37.0"
 description = "Client library for accessing Cofactr data."
 authors = ["Joseph Sayad <joseph@cofactr.com>", "Noah Trueblood <noah@cofactr.com>", "Riley Harrington <riley@cofactr.com>"]
 license = "MIT"


### PR DESCRIPTION
Order presets are pre-configured functions for filling in order data. For example, rather than providing the same billing and shipping information for each request, a user can instead set up a preset that hard-codes that information. They'd then just set `preset_id` instead of `buyer_contact` and `shipping_contact`.